### PR TITLE
install fails on windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE *.py
-recursive-include flask_admin/ *
+recursive-include flask_admin *
 recursive-include docs *
 recursive-exclude docs *.pyc
 recursive-exclude docs *.pyo


### PR DESCRIPTION
Install on windows currently fails with the following error:

ValueError: path 'flask_admin/' cannot end with '/'

This is fixed by removing the trailing slash. Tested by pip install on windows and ubuntu and it works both places.
