### PR TITLE
Fix compatibility with Flask-SQLAlchemy 0.16

### DIFF
--- a/flask_admin/datastore/sqlalchemy.py
+++ b/flask_admin/datastore/sqlalchemy.py
@@ -19,7 +19,7 @@ import types
 
 import flask
 from flask import flash, render_template, redirect, request, url_for
-from flaskext.sqlalchemy import Pagination
+from flask.ext.sqlalchemy import Pagination
 import sqlalchemy as sa
 from sqlalchemy.orm.exc import NoResultFound
 from wtforms import validators, widgets


### PR DESCRIPTION
The new release of Flask-SQLAlchemy moved the package name and the imports in Flask-Admin now break.  This patch uses the "flask.ext" import to provide compatibility with both new and old versions of Flask-SQLAlchemy.
